### PR TITLE
Fixing KC issue with IDP-init call when KC is behind reverse proxy

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -730,7 +730,9 @@ public class SAMLEndpoint {
 
         private String getExpectedDestination(String providerAlias, String clientId) {
             if(clientId != null) {
-                return session.getContext().getUri().getAbsolutePath().toString();
+                //Exaforce - IDP-Init-related fix for https://github.com/ExaForce/operations/issues/9492
+                //return session.getContext().getUri().getAbsolutePath().toString();
+                return Urls.identityProviderAuthnResponse(session.getContext().getUri().getBaseUri(), providerAlias, realm.getName()).toString()+"/clients/"+clientId;
             }
             return Urls.identityProviderAuthnResponse(session.getContext().getUri().getBaseUri(), providerAlias, realm.getName()).toString();
         }


### PR DESCRIPTION
Fixing KC issue with IDP-init call when KC is behind reverse 